### PR TITLE
handle $ref nested more than two levels

### DIFF
--- a/src/dereference.js
+++ b/src/dereference.js
@@ -40,7 +40,11 @@ export const dereferenceSync = (schema) => {
       } else {
         // object
         if ('$ref' in current && typeof current.$ref === 'string') {
-          return resolveRefSync(cloned, current.$ref)
+          let ref = current
+          do {
+            ref = resolveRefSync(cloned, ref.$ref)
+          } while (ref?.$ref)
+          return ref
         }
 
         for (const key in current) {

--- a/src/dereference.test.js
+++ b/src/dereference.test.js
@@ -91,9 +91,15 @@ test('dereferenceSync', async (t) => {
           }
         },
         FirstName: {
-          type: 'string'
+          $ref: '#/schemas/NameComponent'
         },
         LastName: {
+          $ref: '#/schemas/NameComponent'
+        },
+        NameComponent: {
+          $ref: '#/schemas/StringType'
+        },
+        StringType: {
           type: 'string'
         }
       }
@@ -135,6 +141,12 @@ test('dereferenceSync', async (t) => {
           type: 'string'
         },
         LastName: {
+          type: 'string'
+        },
+        NameComponent: {
+          type: 'string'
+        },
+        StringType: {
           type: 'string'
         }
       }


### PR DESCRIPTION
Resolves #52 

Calls `resolveRefSync()` inside a `do...while` loop until the returned value is no longer an object with a $ref property, or is null.

Tests updated.